### PR TITLE
Fully use Redmines Project-based Roles/Permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,12 @@ gem 'acts_as_list'
 # these are required in order to run the specs with 'rspec-rails' in EasyRedmine
 # uncomment those in order to run the specs via 'rspec' command
 # please note: the gems need to be exactly the same versions as given in your host redmine application Gemfile
-#gem 'rails', '4.2.5'
-#gem 'actionpack-xml_parser'
-#gem 'mysql2', '~> 0.3.11'
-#gem 'rack-openid'
-#gem 'protected_attributes'
-#gem 'request_store', '1.0.5'
+gem 'rails', '4.2.5'
+gem 'actionpack-xml_parser'
+gem 'mysql2', '~> 0.3.11'
+gem 'rack-openid'
+gem 'protected_attributes'
+gem 'request_store', '1.0.5'
 
 group :development, :test do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,16 @@ source 'https://rubygems.org'
 gem 'acts_as_list'
 
 # these are required in order to run the specs with 'rspec-rails' in EasyRedmine
-# uncomment those in order to run the specs via 'rspec' command
+# use RAILS_ENV=test in order to run the specs via 'rspec' command
 # please note: the gems need to be exactly the same versions as given in your host redmine application Gemfile
-gem 'rails', '4.2.5'
-gem 'actionpack-xml_parser'
-gem 'mysql2', '~> 0.3.11'
-gem 'rack-openid'
-gem 'protected_attributes'
-gem 'request_store', '1.0.5'
+if ENV['RAILS_ENV'] == 'test'
+  gem 'rails', '4.2.5'
+  gem 'actionpack-xml_parser'
+  gem 'mysql2', '~> 0.3.11'
+  gem 'rack-openid'
+  gem 'protected_attributes'
+  gem 'request_store', '1.0.5'
+end
 
 group :development, :test do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,9 +61,9 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (3.0)
+    mime-types (3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0221)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.12.0)
@@ -159,3 +159,6 @@ DEPENDENCIES
   request_store (= 1.0.5)
   rspec-rails
   simplecov (~> 0.9.1)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The User can set an unavailable_from/unavailable_to date. An Issue cant be assig
 
 An user can have a set of other users that will act as deputies if the user not available. These can be created for an specific project or for this user in general
 
+### Permissions within the Projects
+In Order to use the Deputy System, the following things need to be set up:
+
+- Enable "User Deputies" Module for the Project
+- Assign the according rights (Have Deputies / Be Deuputy) to your project members via Roles
+
 ## Info
 
 This Plugin was created by Florian Eck for akquinet GmbH.

--- a/app/controllers/user_deputies_controller.rb
+++ b/app/controllers/user_deputies_controller.rb
@@ -4,7 +4,7 @@ class UserDeputiesController < ApplicationController
   before_filter :get_entry, except: [:index, :set_availabilities, :projects_for_user]
 
   def index
-    @users = User.with_deputy_permission(:be_deputy).where.not(id: @user.id)
+    @users = User.with_deputy_permission(:be_deputy).where.not(id: @user.id).status(User::STATUS_ACTIVE)
     @projects =  @user.projects_with_have_deputies_permission
     @user_deputies_with_projects    = UserDeputy.with_projects.where(:user_id => User.current.id)
     @user_deputies_without_projects = UserDeputy.without_projects.where(:user_id => User.current.id)

--- a/app/controllers/user_deputies_controller.rb
+++ b/app/controllers/user_deputies_controller.rb
@@ -5,7 +5,7 @@ class UserDeputiesController < ApplicationController
 
   def index
     @users = User.with_deputy_permission(:be_deputy).where.not(id: @user.id)
-    @projects = Project.visible
+    @projects =  @user.projects_with_have_deputies_permission
     @user_deputies_with_projects    = UserDeputy.with_projects.where(:user_id => User.current.id)
     @user_deputies_without_projects = UserDeputy.without_projects.where(:user_id => User.current.id)
   end

--- a/app/controllers/user_deputies_controller.rb
+++ b/app/controllers/user_deputies_controller.rb
@@ -1,7 +1,7 @@
 class UserDeputiesController < ApplicationController
 
-  before_filter :check_permission, :get_user
-  before_filter :get_entry, except: [:index, :set_availabilities]
+  before_filter :check_permission, :get_user, except: [:projects_for_user_user_deputies]
+  before_filter :get_entry, except: [:index, :set_availabilities, :projects_for_user_user_deputies]
 
   def index
     @users = User.with_deputy_permission(:be_deputy).where.not(id: @user.id)
@@ -50,6 +50,12 @@ class UserDeputiesController < ApplicationController
     end
 
     redirect_to action: :index
+  end
+
+  def projects_for_user
+    @user = User.find(params[:user_id])
+    @projects = @user.projects_with_be_deputy_permission
+    render partial: "/user_deputies/project_selector"
   end
 
   private

--- a/app/controllers/user_deputies_controller.rb
+++ b/app/controllers/user_deputies_controller.rb
@@ -1,7 +1,7 @@
 class UserDeputiesController < ApplicationController
 
-  before_filter :check_permission, :get_user, except: [:projects_for_user_user_deputies]
-  before_filter :get_entry, except: [:index, :set_availabilities, :projects_for_user_user_deputies]
+  before_filter :check_permission, :get_user, except: [:projects_for_user]
+  before_filter :get_entry, except: [:index, :set_availabilities, :projects_for_user]
 
   def index
     @users = User.with_deputy_permission(:be_deputy).where.not(id: @user.id)

--- a/app/models/user_deputy.rb
+++ b/app/models/user_deputy.rb
@@ -13,4 +13,12 @@ class UserDeputy < ActiveRecord::Base
 
   acts_as_list column: :prio, scope: :project
 
+  def enable!
+    self.update_attributes(disabled: false, disabled_at: nil)
+  end
+
+  def disable!
+    self.update_attributes(disabled: true, disabled_at: Time.now)
+  end
+
 end

--- a/app/models/user_deputy.rb
+++ b/app/models/user_deputy.rb
@@ -9,7 +9,7 @@ class UserDeputy < ActiveRecord::Base
   scope :without_projects, -> { unscoped.order(:prio).where(project_id: nil) }
 
   validates_presence_of :user_id, :deputy_id
-  validates_uniqueness_of :deputy, :scope => [:user, :project]
+  validates_uniqueness_of :deputy, :scope => [:user, :project], on: :create
 
   acts_as_list column: :prio, scope: :project
 

--- a/app/views/user_deputies/_project_selector.html.erb
+++ b/app/views/user_deputies/_project_selector.html.erb
@@ -1,0 +1,4 @@
+<%= fields_for UserDeputy.new do |f| %>
+  <%= f.label :project_id, UserDeputy.human_attribute_name(:project)  %><br />
+  <%= f.select :project_id, @projects.map {|p| [p.name, p.id]}, {include_blank: t('user_deputies.index.form.all_projects')} %><br /><br />
+<% end %>

--- a/app/views/user_deputies/index.html.erb
+++ b/app/views/user_deputies/index.html.erb
@@ -40,11 +40,19 @@
         <% end %>
         <tr>
           <td>
-            <%= link_to image_tag('1downarrow.png'), move_down_user_deputy_path(user_deputy), title: t('.links.move_down') %>
-            <%= link_to image_tag('1uparrow.png'), move_up_user_deputy_path(user_deputy), title: t('.links.move_up') %>
+            <% if !user_deputy.disabled? %>
+              <%= link_to image_tag('1downarrow.png'), move_down_user_deputy_path(user_deputy), title: t('.links.move_down') %>
+              <%= link_to image_tag('1uparrow.png'), move_up_user_deputy_path(user_deputy), title: t('.links.move_up') %>
+            <% end %>
             <%= link_to image_tag('delete.png'), delete_user_deputy_path(user_deputy), { title: t('.links.delete') } %>
           </td>
-          <td><%= user_deputy.prio %></td>
+          <td>
+            <% if user_deputy.disabled? %>
+              <%= t(".disabled") %>
+            <% else %>
+              <%= user_deputy.prio %>
+            <% end %>
+          </td>
           <td><%= user_deputy.deputy.name %></td>
         </tr>
       <% end %>

--- a/app/views/user_deputies/index.html.erb
+++ b/app/views/user_deputies/index.html.erb
@@ -71,9 +71,8 @@
     <%= form_for UserDeputy.new do |f| %>
       <h4><%= t('.sub_header.new_deputy') %></h4>
       <%= f.label :deputy_id, UserDeputy.human_attribute_name(:deputy) %><br />
-      <%= f.select :deputy_id, @users.order(:lastname).map {|u| [u.name(:lastname_firstname), u.id]} %><br />
-      <%= f.label :project_id, UserDeputy.human_attribute_name(:project)  %><br />
-      <%= f.select :project_id, @projects.map {|u| [u.name, u.id]}, {include_blank: t('.form.all_projects')} %><br /><br />
+      <%= f.select :deputy_id, @users.order(:lastname).map {|u| [u.name(:lastname_firstname), u.id]}, include_blank: true %><br />
+      <div id="deputy-project-select"><%= t('.form.select_deputy') %></div>
       <%= f.submit  t('.form.submit_deputy'), class: 'button-positive' %>
     <% end %>
 
@@ -86,4 +85,24 @@
     #sidebar { z-index: 99 !important;}
     #ui-datepicker-div { z-index: 101 !important;}
   </style>
+
+  <%# JS for reloading projects %>
+  <script type="text/javascript">
+    $(document).ready(function(){
+      $('#user_deputy_deputy_id').bind('change', function(){
+        if($(this).val() == ''){
+          alert("<%= t('.form.select_deputy') %>")
+        }else{
+          $.ajax({
+            url: "<%= projects_for_user_user_deputies_path %>",
+            type: "GET",
+            data: {user_id: $(this).val() },
+            success: function(data){
+              $('#deputy-project-select').html(data)
+            }
+          })
+        }
+      });
+    });
+  </script>
 <% end %>

--- a/app/views/user_deputies/index.html.erb
+++ b/app/views/user_deputies/index.html.erb
@@ -4,7 +4,7 @@
     <% if User.current.allowed_to_globally?(:edit_deputies) %>
       <%= t(".select_user") %>
       <%= select_tag :user_id,
-        options_for_select(User.with_deputy_permission(:have_deputies).order(:lastname).map {|u| [u.name(:lastname_firstname), u.id]}, selected: @user.id),
+        options_for_select(User.with_deputy_permission(:have_deputies).status(User::STATUS_ACTIVE).order(:lastname).map {|u| [u.name(:lastname_firstname), u.id]}, selected: @user.id),
         onchange: "window.location='#{user_deputies_path}?user_id='+this.value" %>
     <% end %>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -29,6 +29,7 @@ de:
     index:
       header: 'Verfügbarkeiten und Vertretung (%{user_name})'
       select_user: Benutzer wählen
+      disabled: deaktiviert
       sub_header:
         availabilities: Verfügbarkeiten
         deputies: Vertretungen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -44,6 +44,7 @@ de:
         submit_deputy: 'Vertretung anlegen'
         submit_availability: 'Abwesenheit speichern'
         submit_permissions: 'Rechte speichern'
+        select_deputy: "Bitte vertretenden Benutzer wählen"
         labels:
           unavailable_from: Abwesend von
           unavailable_to: Abwesend bis

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -40,7 +40,7 @@ de:
         name: Name
         project: Projekt
       form:
-        all_projects: Gilt für alle Projekte
+        all_projects: Gilt für alle aktivierten Projekte
         submit_deputy: 'Vertretung anlegen'
         submit_availability: 'Abwesenheit speichern'
         submit_permissions: 'Rechte speichern'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     index:
       header: 'Availability/Deputies (%{user_name})'
       select_user: Select user
+      disabled: disabled
       sub_header:
         availabilities: Availability
         deputies: Deputies

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en:
         name: Name
         project: Project
       form:
-        all_projects: Valid for all projects
+        all_projects: Valid for all enabled projects
         submit_deputy: 'Create deputy'
         submit_availability: 'Save unvailabilities'
         submit_permissions: 'Save permissions'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,7 @@ en:
         submit_deputy: 'Create deputy'
         submit_availability: 'Save unvailabilities'
         submit_permissions: 'Save permissions'
+        select_deputy: "Please select Deputy"
         labels:
           unavailable_from: Unvailable from
           unavailable_to: Unvailable to

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 RedmineApp::Application.routes.draw do
   resources :user_deputies, only: [:index, :create] do
+
     member do
       get :move_up
       get :move_down
@@ -9,6 +10,7 @@ RedmineApp::Application.routes.draw do
     collection do
       post :set_availabilities
       post :set_permissions
+      get  :projects_for_user
     end
   end
 end

--- a/db/migrate/005_add_disabled_flag_to_user_deputy.rb
+++ b/db/migrate/005_add_disabled_flag_to_user_deputy.rb
@@ -1,0 +1,8 @@
+class AddDisabledFlagToUserDeputy < ActiveRecord::Migration
+
+  def change
+    add_column :user_deputies, :disabled, :boolean, :default => false
+    add_column :user_deputies, :disabled_at, :datetime
+  end
+
+end

--- a/init.rb
+++ b/init.rb
@@ -6,9 +6,15 @@ Redmine::Plugin.register :redmine_auto_deputy do
 
   menu :top_menu, :deputies, { :controller => 'user_deputies', :action => 'index' }, :caption => :deputies, if: Proc.new { User.current.logged? && User.current.allowed_to_globally?(:have_deputies) }, :html => {:class => 'icon icon-time'}
 
-  permission :edit_deputies, { user_deputies: [:index, :move_up, :move_down, :create, :delete, :set_availabilities] }, :global => true, :read => true
-  permission :have_deputies, {  user_deputies: [:index, :move_up, :move_down, :create, :delete, :set_availabilities] }, :global => true, :read => true
-  permission :be_deputy,     { user_deputies: [] }, :global => true, :read => true
+  Redmine::AccessControl.map do |map|
+    map.project_module :user_deputies do |pmap|
+      pmap.permission :edit_deputies, { user_deputies: [:index, :move_up, :move_down, :create, :delete, :set_availabilities] }, global: true
+      pmap.permission :have_deputies, { user_deputies: [:index, :move_up, :move_down, :create, :delete, :set_availabilities] }
+      pmap.permission :be_deputy,     { user_deputies: [] }
+    end
+  end
+
+
 
 end
 

--- a/init.rb
+++ b/init.rb
@@ -6,9 +6,9 @@ Redmine::Plugin.register :redmine_auto_deputy do
 
   menu :top_menu, :deputies, { :controller => 'user_deputies', :action => 'index' }, :caption => :deputies, if: Proc.new { User.current.logged? && User.current.allowed_to_globally?(:have_deputies) }, :html => {:class => 'icon icon-time'}
 
-  permission :edit_deputies, {}, :global => true
-  permission :have_deputies, {}, :global => true
-  permission :be_deputy, {}, :global => true
+  permission :edit_deputies, { user_deputies: [:index, :move_up, :move_down, :create, :delete, :set_availabilities] }, :global => true, :read => true
+  permission :have_deputies, {  user_deputies: [:index, :move_up, :move_down, :create, :delete, :set_availabilities] }, :global => true, :read => true
+  permission :be_deputy,     { user_deputies: [] }, :global => true, :read => true
 
 end
 

--- a/lib/redmine_auto_deputy/user_deputy_extension.rb
+++ b/lib/redmine_auto_deputy/user_deputy_extension.rb
@@ -26,6 +26,10 @@ module RedmineAutoDeputy::UserDeputyExtension
 
     deputies.each do |d|
       if d.deputy.available_at?(date) && d.deputy.can_be_deputy_for_project?(project_id)
+        if d.disabled?
+          d.enable!
+        end
+
         deputies_available << d
       elsif !d.deputy.can_be_deputy_for_project?(project_id) && !d.disabled?
         d.disable!

--- a/lib/redmine_auto_deputy/user_deputy_extension.rb
+++ b/lib/redmine_auto_deputy/user_deputy_extension.rb
@@ -21,8 +21,15 @@ module RedmineAutoDeputy::UserDeputyExtension
     return if (project_id.present? && !can_have_deputies_for_project?(project_id))
 
     deputies = user_deputies.where(project_id: [nil, project_id].uniq ).where.not(deputy_id: already_tried)
-    deputies_available = deputies.select do |d|
-      d.deputy.available_at?(date) && d.deputy.can_be_deputy_for_project?(project_id)
+
+    deputies_available = []
+
+    deputies.each do |d|
+      if d.deputy.available_at?(date) && d.deputy.can_be_deputy_for_project?(project_id)
+        deputies_available << d
+      elsif !d.deputy.can_be_deputy_for_project?(project_id) && !d.disabled?
+        d.disable!
+      end
     end
 
     if deputies_available.any?

--- a/spec/controllers/user_deputies_controller_spec.rb
+++ b/spec/controllers/user_deputies_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe UserDeputiesController, type: :controller do
       specify do
         get :index
 
-        expect(assigns[:users].to_sql).to eq("SELECT `users`.* FROM `users` INNER JOIN `members` ON `members`.`user_id` = `users`.`id` INNER JOIN `member_roles` ON `member_roles`.`member_id` = `members`.`id` INNER JOIN `roles` ON `roles`.`id` = `member_roles`.`role_id` WHERE `users`.`type` IN ('User', 'AnonymousUser') AND `member_roles`.`role_id` IN (1, 2) AND (`users`.`id` != #{current_user.id}) GROUP BY `users`.`id`")
+        expect(assigns[:users].to_sql).to eq("SELECT `users`.* FROM `users` INNER JOIN `members` ON `members`.`user_id` = `users`.`id` INNER JOIN `member_roles` ON `member_roles`.`member_id` = `members`.`id` INNER JOIN `roles` ON `roles`.`id` = `member_roles`.`role_id` WHERE `users`.`type` IN ('User', 'AnonymousUser') AND `member_roles`.`role_id` IN (1, 2) AND (`users`.`id` != #{current_user.id}) AND `users`.`status` = #{User::STATUS_ACTIVE} GROUP BY `users`.`id`")
         expect(assigns[:user]).to eq(current_user)
         expect(assigns[:projects]).to eq(projects)
         expect(assigns[:user_deputies_with_projects].to_sql).to eq("SELECT `user_deputies`.* FROM `user_deputies` INNER JOIN `projects` ON `projects`.`id` = `user_deputies`.`project_id` WHERE (`user_deputies`.`project_id` IS NOT NULL) AND `user_deputies`.`user_id` = #{current_user.id}  ORDER BY projects.name ASC, `user_deputies`.`prio` ASC")

--- a/spec/controllers/user_deputies_controller_spec.rb
+++ b/spec/controllers/user_deputies_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UserDeputiesController, type: :controller do
     let(:filter) { described_class._process_action_callbacks.select {|c| c.filter == :get_entry }.first }
     specify ':get_entry, except: [:index, :set_availabilities]' do
       expect(filter.kind).to eq(:before)
-      expect(filter.instance_variable_get('@unless')).to eq(["action_name == 'index' || action_name == 'set_availabilities'"])
+      expect(filter.instance_variable_get('@unless')).to eq(["action_name == 'index' || action_name == 'set_availabilities' || action_name == 'projects_for_user'"])
     end
   end
 
@@ -192,6 +192,18 @@ RSpec.describe UserDeputiesController, type: :controller do
         expect(flash[:error]).to eq(I18n.t('user_deputies.set_availabilities.error.not_saved', errors: assigns[:user].errors.full_messages.to_sentence))
         expect(response).to redirect_to(user_deputies_path)
       end
+    end
+  end
+
+  describe '#projects_for_user' do
+    let(:projects) { [double(:project, id: 1, name: 'Project')] }
+    before { expect_any_instance_of(User).to receive(:projects_with_be_deputy_permission).and_return(projects) }
+
+    specify do
+      get :projects_for_user, user_id: current_user.id
+      expect(assigns[:user]).to eq(current_user)
+      expect(assigns[:projects]).to eq(projects)
+      expect(response).to render_template(partial: 'user_deputies/project_selector')
     end
   end
 

--- a/spec/lib/redmine_auto_deputy/user_deputy_extension_spec.rb
+++ b/spec/lib/redmine_auto_deputy/user_deputy_extension_spec.rb
@@ -96,4 +96,35 @@ RSpec.describe RedmineAutoDeputy::UserDeputyExtension do
     end
   end
 
+
+  context 'project permission finders' do
+    let(:user) { build(:user, id: 1) }
+
+    describe '#projects_with_have_deputies_permission' do
+      before do
+        expect(Project).to receive(:allowed_to_condition).with(user, :have_deputies).and_return('1 = 0')
+      end
+
+      specify { expect(user.projects_with_have_deputies_permission.to_sql).to eq("SELECT `projects`.* FROM `projects` WHERE (1 = 0)") }
+    end
+
+    describe  '#can_have_deputies_for_project?' do
+      before { expect(user).to receive_message_chain(:projects_with_have_deputies_permission, :pluck).with(:id).and_return([1]) }
+      specify { expect(user.can_have_deputies_for_project?(1)).to be(true)}
+    end
+
+    describe '#projects_with_be_deputy_permission' do
+      before do
+        expect(Project).to receive(:allowed_to_condition).with(user, :be_deputy).and_return('1 = 0')
+      end
+
+      specify { expect(user.projects_with_be_deputy_permission.to_sql).to eq("SELECT `projects`.* FROM `projects` WHERE (1 = 0)") }
+    end
+
+    describe  '#can_be_deputy_for_project?' do
+      before { expect(user).to receive_message_chain(:projects_with_be_deputy_permission, :pluck).with(:id).and_return([1]) }
+      specify { expect(user.can_be_deputy_for_project?(1)).to be(true)}
+    end
+  end
+
 end

--- a/spec/lib/redmine_auto_deputy/user_deputy_extension_spec.rb
+++ b/spec/lib/redmine_auto_deputy/user_deputy_extension_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe RedmineAutoDeputy::UserDeputyExtension do
 
       before do
         expect(user).to receive(:can_have_deputies_for_project?).with(1).and_return(true)
-        expect_any_instance_of(User).to receive(:can_be_deputy_for_project?).with(1).and_call_original
+        expect_any_instance_of(User).to receive(:can_be_deputy_for_project?).with(1).exactly(2).times.and_call_original
       end
 
       specify do

--- a/spec/models/user_deputy_spec.rb
+++ b/spec/models/user_deputy_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 RSpec.describe UserDeputy do
 
-  let(:user_deputy) { build(:user_deputy) }
+  let(:user_deputy) { create(:user_deputy, user_id: rand(10000), deputy_id: rand(10000)) }
 
   specify { expect(described_class.all.to_sql).to eq("SELECT `user_deputies`.* FROM `user_deputies`  ORDER BY `user_deputies`.`project_id` DESC, `user_deputies`.`prio` ASC")}
 

--- a/spec/models/user_deputy_spec.rb
+++ b/spec/models/user_deputy_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 RSpec.describe UserDeputy do
 
+  let(:user_deputy) { build(:user_deputy) }
+
   specify { expect(described_class.all.to_sql).to eq("SELECT `user_deputies`.* FROM `user_deputies`  ORDER BY `user_deputies`.`project_id` DESC, `user_deputies`.`prio` ASC")}
 
   describe 'scopes' do
@@ -15,5 +17,20 @@ RSpec.describe UserDeputy do
   end
 
   specify { expect(described_class.included_modules).to include(ActiveRecord::Acts::List::InstanceMethods)}
+
+
+  context "enable/disable" do
+    before { allow(Time).to receive(:now).and_return(DateTime.new(2016,1,1,1,1)) }
+
+    describe '#enable!' do
+      before { expect(user_deputy).to receive(:update_attributes).with(disabled: false, disabled_at: nil).and_call_original }
+      specify { expect(user_deputy.enable!).to be(true) }
+    end
+
+    describe '#disable!' do
+      before { expect(user_deputy).to receive(:update_attributes).with(disabled: true, disabled_at: Time.now).and_call_original }
+      specify { expect(user_deputy.disable!).to be(true) }
+    end
+  end
 
 end


### PR DESCRIPTION
- [x] Es können nur Projekte ausgewählt werden in denen Der Benutzer die Rolle "Darf Deputies haben" besitzt
- [x] Es können nur Benutzer ausgewählt werden in denen Sie die Rolle "Darf Deputy sein" besitzen
- [x] Benutzerauswahl muss dynamisch nachgeladen werden

- [x] Bei globalen Deputies muss vor Zuweisung zum Issue geprüft werden ob der Benutzer entspr. des Projekt/seiner Rolle überhaupt zugewiesen werden darf

- [x] Werden ungültige Deputies gefunden werden diese deaktiviert und in der Übersicht als deaktiviert angezeigt, so dass der Benutzer diese löschen kann  

- [x] When "UserDeputies" Module is disabled for a Project, all deputies should be disabled on checkup